### PR TITLE
Updated PrettyFaces version on documentation page

### DIFF
--- a/pages/prettyfaces/docs.page
+++ b/pages/prettyfaces/docs.page
@@ -11,7 +11,7 @@
 
 <div class="featured">
 
-<center><div class="inside"><h2><font color="green">CELEBRATE!</font> PrettyFaces version 3.3.2 is Released!</h2></div>
+<center><div class="inside"><h2><font color="green">CELEBRATE!</font> PrettyFaces version 3.3.3 is Released!</h2></div>
 
 <h2>Read the reference documentation: <a target="_blank" href="http://ocpsoft.com/docs/prettyfaces/3.3.2/en-US/html/">web view</a>, or <a target="_blank" href="http://ocpsoft.com/docs/prettyfaces/3.3.2/en-US/html_single/">single page</a>.</h2></center>
 
@@ -22,21 +22,21 @@ Maven dependencies:
 <dependency>
 	<groupId>com.ocpsoft</groupId>
 	<artifactId>prettyfaces-jsf11</artifactId>
-	<version>3.3.2</version>
+	<version>3.3.3</version>
 </dependency>
 
 <!-- For Servlet/Java EE and JSF 1.2 -->
 <dependency>
 	<groupId>com.ocpsoft</groupId>
 	<artifactId>prettyfaces-jsf12</artifactId>
-	<version>3.3.2</version>
+	<version>3.3.3</version>
 </dependency>
 
 <!-- For Servlet/Java EE and JSF 2.0 -->
 <dependency>
 	<groupId>com.ocpsoft</groupId>
 	<artifactId>prettyfaces-jsf2</artifactId>
-	<version>3.3.2</version>
+	<version>3.3.3</version>
 </dependency>
 </pre>
 </div>


### PR DESCRIPTION
The PrettyFaces documentation page still references version 3.3.2. This pull request updates the text on the page to 3.3.3. Please not that the links still point to the docs of 3.3.2. We should update this sometime. But the docs didn't change. So I think this is not very important. But I think it is important to have 3.3.3 on the page as there are also examples for how to add PrettyFaces to you pom.xml.
